### PR TITLE
fix: use proper shebang

### DIFF
--- a/cgi-bin/register.py
+++ b/cgi-bin/register.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python3.7
+#! /usr/bin/python3
 from parameters import *
 import base64
 import cgi


### PR DESCRIPTION
Fix: `bash: ./register.py: /usr/bin/python3.7: bad interpreter: No such file or directory`